### PR TITLE
add support for Tables in model fit and transform, add flag for table

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,7 +46,7 @@ rng = StableRNGs.StableRNG(123)
     X, _ = make_regression(100, 5)
     mach = machine(model, X)
     fit!(mach, verbosity=0)
-    X_transformed = transform(mach, X_dense)
+    X_transformed = transform(mach, X)
     
     @test length(keys(X_transformed)) == 2
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,4 +41,12 @@ rng = StableRNGs.StableRNG(123)
     @test size(X_transformed) == (10, 2)
     @test isapprox(s, fitted_params(mach).singular_values)
     @test size(V) == size(fitted_params(mach).components)
+
+    # test tables
+    X, _ = make_regression(100, 5)
+    mach = machine(model, X)
+    fit!(mach, verbosity=0)
+    X_transformed = transform(mach, X_dense)
+    
+    @test length(keys(X_transformed)) == 2
 end


### PR DESCRIPTION
Initial attempt at adding support for Tables in fit and transform methods.  In terms of a flag on the `fitresult`, would the Bool type work here?