### PR TITLE
Add tests from MLJTestInteface and fix issue with row tables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,20 +4,23 @@ authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>", "Chris Alexander <uvapa
 version = "0.1.5"
 
 [deps]
+MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 TSVD = "9449cd9e-2762-5aa3-a617-5413e99d722e"
 
 [compat]
 MLJModelInterface = "1.1.1"
+Random = "<0.0.1, 1"
 TSVD = "0.4.3"
 julia = "1.6"
 
 [extras]
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
+MLJTestInterface = "72560011-54dd-4dc2-94f3-c5de45b75ecd"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["MLJBase", "SparseArrays", "StableRNGs", "Test"]
+test = ["MLJBase", "MLJTestInterface", "SparseArrays", "StableRNGs", "Test"]

--- a/src/MLJTSVDInterface.jl
+++ b/src/MLJTSVDInterface.jl
@@ -20,7 +20,7 @@ struct TSVDTransformerResult
 end
 
 as_matrix(X) = MMI.matrix(X)
-as_matrix(X::AbstractArray) = X
+as_matrix(X::AbstractMatrix) = X
 
 _get_rng(rng::Int) = MersenneTwister(rng)
 _get_rng(rng) = rng

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,10 @@
-using MLJTSVDInterface # substitute for correct interface pkg name
+using MLJTSVDInterface
 using Test
 using TSVD
 using MLJBase
 using SparseArrays
 using StableRNGs # for RNGs stable across all julia versions
+using MLJTestInterface
 
 const rng = StableRNGs.StableRNG(123)
 
@@ -48,7 +49,7 @@ const rng = StableRNGs.StableRNG(123)
     mach = machine(model, X)
     fit!(mach, verbosity=0)
     X_transformed = transform(mach, X)
-    
+
     @test length(keys(X_transformed)) == 2
 
     # test with default RNG
@@ -64,4 +65,20 @@ const rng = StableRNGs.StableRNG(123)
     @test size(X_transformed) == (10, 2)
     @test isapprox(s, fitted_params(mach).singular_values)
     @test size(V) == size(fitted_params(mach).components)
+end
+
+@testset "generic interface tests" begin
+    for data in first.([
+        MLJTestInterface.make_regression(),
+        MLJTestInterface.make_regression(row_table=true),
+        ])
+        failures, summary = MLJTestInterface.test(
+            [TSVDTransformer,],
+            data,
+            mod=@__MODULE__,
+            verbosity=2, # bump to debug
+            throw=false, # set to true to debug
+        )
+        @test isempty(failures)
+    end
 end


### PR DESCRIPTION
There is bug when user attempts to use a row table, instead of, say a column-based table like a DataFrame.

This PR fixes the bug and adds generic interface tests from MLJTestInterface that catches that kind of bug.